### PR TITLE
Give option for manual px variant override

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ You can pass `width` or `height` or both for your desired size:
 If only `width` or `height` is passed, then the other scales accordingly.
 
 Note: The default size is 16px by 16px.
+
+### 16px and 24px variants
+
+The icon variant chosen is dependent on the size specified. If either your width or height is more than 16, then the 24px variant will be chosen.
+
+#### What if I want to specify a variant regardless of size?
+
+If say, you wanted a 32 width icon, but wanted to use the 16px variant, you can do so by specifying the whole variant name, in the form `{ICON_NAME}-{ICON_SIZE}`:
+
+```{% octicon "alert-16" width="32" %}```

--- a/octicons_v10/templatetags/octicons.py
+++ b/octicons_v10/templatetags/octicons.py
@@ -14,13 +14,16 @@ class Octicon:
     """Class representing a GitHub Octicon."""
 
     def __init__(self, icon_name, **attributes):
-        self.icon_name = icon_name
         self.attributes = attributes
 
         self.set_size(int(attributes.get("width", 0)), int(attributes.get("height", 0)))
 
-        # Must check if 24px variant exists as some icons do not have 24px variant
-        self.icon_size = self.get_icon_size(icon_name)
+        # Check if manually specified size. (!) This assumes all icon names are in the form {icon_name}-{icon_size}
+        if icon_name in ICON_PATHS.keys():
+            self.icon_name, self.icon_size = "-".join(icon_name.split("-")[:-1]), int(icon_name.split("-")[-1])
+        else:
+            # Must check if 24px variant exists as some icons do not have 24px variant
+            self.icon_name, self.icon_size = icon_name, self.get_icon_size(icon_name)
 
         if self.get_path() is None:
             raise KeyError("Could not find data for icon '" + icon_name + "' in icon set.")

--- a/octicons_v10/templatetags/octicons.py
+++ b/octicons_v10/templatetags/octicons.py
@@ -23,7 +23,7 @@ class Octicon:
             self.icon_name, self.icon_size = "-".join(icon_name.split("-")[:-1]), int(icon_name.split("-")[-1])
         else:
             # Must check if 24px variant exists as some icons do not have 24px variant
-            self.icon_name, self.icon_size = icon_name, self.get_icon_size(icon_name)
+            self.icon_name, self.icon_size = icon_name, self._calculate_icon_size(icon_name)
 
         if self.get_path() is None:
             raise KeyError("Could not find data for icon '" + icon_name + "' in icon set.")
@@ -41,7 +41,7 @@ class Octicon:
         else:
             self.attributes["width"], self.attributes["height"] = max(width, height), max(width, height)
 
-    def get_icon_size(self, icon_name):
+    def _calculate_icon_size(self, icon_name):
         if max(self.attributes["height"], self.attributes["width"]) > 16 and ICON_PATHS.get(icon_name + "-24"):
             return 24
         return 16

--- a/octicons_v10/templatetags/octicons.py
+++ b/octicons_v10/templatetags/octicons.py
@@ -20,7 +20,7 @@ class Octicon:
         self.set_size(int(attributes.get("width", 0)), int(attributes.get("height", 0)))
 
         # Must check if 24px variant exists as some icons do not have 24px variant
-        self.icon_size = 24 if max(self.attributes["height"], self.attributes["width"]) > 16 and ICON_PATHS.get(icon_name + "-24") else 16
+        self.icon_size = self.get_icon_size(icon_name)
 
         if self.get_path() is None:
             raise KeyError("Could not find data for icon '" + icon_name + "' in icon set.")
@@ -37,6 +37,11 @@ class Octicon:
             self.attributes["width"], self.attributes["height"] = 16, 16
         else:
             self.attributes["width"], self.attributes["height"] = max(width, height), max(width, height)
+
+    def get_icon_size(self, icon_name):
+        if max(self.attributes["height"], self.attributes["width"]) > 16 and ICON_PATHS.get(icon_name + "-24"):
+            return 24
+        return 16
 
     def get_classes(self):
         return ("octicon octicon-" + self.icon_name + " " + self.attributes.get("class", "")).strip()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="django-octicons-v10",
     packages=find_packages(exclude=("tests",)),
     package_data={"octicons_v10": ["templatetags/octicons.json"]},
-    version="1.0.4",
+    version="1.1.0",
     license="MIT",
     description="Django templatetags for GitHub Octicons v10.0.0.",
     long_description=long_description,
@@ -15,7 +15,7 @@ setup(
     author='Jay Newey',
     author_email="jay.newey01@gmail.com",
     url="https://github.com/jaynewey/django-octicons-v10",
-    download_url="https://github.com/jaynewey/django-octicons-v10/archive/1.0.4.tar.gz",
+    download_url="https://github.com/jaynewey/django-octicons-v10/archive/v1.1.0.tar.gz",
     keywords=["octicons", "django", "templatetags"],
     install_requires=[
         "Django>=2.0.0,<3.0.0",

--- a/tests/test_octicon.py
+++ b/tests/test_octicon.py
@@ -57,3 +57,12 @@ def test_convert_attributes():
     assert 'aria-hidden="true"' in attributes
     assert 'fill="currentColor"' in attributes
     assert 'style="color: #ffffff;"' in attributes
+
+
+def test_manual_px_variant():
+    octicon = Octicon("zap-24")
+    assert octicon.icon_name == "zap" and octicon.attributes["width"] == 16 and octicon.icon_size == 24
+    octicon = Octicon("zap-16", **{"width": "24"})
+    assert octicon.icon_name == "zap" and octicon.attributes["width"] == 24 and octicon.icon_size == 16
+    octicon = Octicon("zap-24", **{"width": "16"})
+    assert octicon.icon_name == "zap" and octicon.attributes["width"] == 16 and octicon.icon_size == 24


### PR DESCRIPTION
Resolves #2.

Allow users to manually override variant calculation by specifying which variant they want to use.

Example usage:

```{% octicon "alert-16" width="32" %}```

For if the user wants to use the 16px variant of the icon at larger sizes, for example.